### PR TITLE
Keycloak changes for SDK

### DIFF
--- a/api/rest/api.js
+++ b/api/rest/api.js
@@ -52,8 +52,7 @@ module.exports.auth = {
     TOKEN:                  '/v1/api/auth/token',
     TOKEN_INFO:             '/v1/api/auth/tokenInfo',
     USER_INFO:              '/v1/api/auth/me',
-    REFRESH_TOKEN:          '/v1/api/auth/refresh',
-    REVOKE_REFRESH_TOKEN:   '/v1/api/auth/refresh/revoke'
+    REFRESH_TOKEN:          '/v1/api/auth/refresh'
 }
 
 module.exports.cmpcatalog = {
@@ -76,6 +75,7 @@ module.exports.control = {
 
 module.exports.data = {
     SEND:                   '/v1/api/data/{deviceid}',
+    SEND_AS_USER:           '/v1/api/accounts/{accountId}/data/{deviceId}',
     SEARCH:                 '/v1/api/accounts/{accountId}/data/search',
     SEARCH_ADVANCED:        '/v1/api/accounts/{accountId}/data/search/advanced'
 }

--- a/api/rest/auth.def.js
+++ b/api/rest/auth.def.js
@@ -65,17 +65,7 @@ module.exports = function(config) {
     GetAuthUserInfoOption.prototype = new ConnectionOptions();
     GetAuthUserInfoOption.prototype.constructor = GetAuthUserInfoOption;
     module.GetAuthUserInfoOption = GetAuthUserInfoOption;
-
-    function GetRefreshTokenOption(data) {
-        this.pathname = common.buildPath(api.auth.REFRESH_TOKEN);
-        this.token = data.token;
-        ConnectionOptions.call(this);
-        this.method = 'POST';
-        this.body = null;
-    }
-    GetRefreshTokenOption.prototype = new ConnectionOptions();
-    GetRefreshTokenOption.prototype.constructor = GetRefreshTokenOption;
-    module.GetRefreshTokenOption = GetRefreshTokenOption;
+    
 
     function RefreshAuthTokenOption(data) {
         this.pathname = common.buildPath(api.auth.REFRESH_TOKEN);
@@ -87,17 +77,6 @@ module.exports = function(config) {
     RefreshAuthTokenOption.prototype = new ConnectionOptions();
     RefreshAuthTokenOption.prototype.constructor = RefreshAuthTokenOption;
     module.RefreshAuthTokenOption = RefreshAuthTokenOption;
-
-    function RevokeRefreshTokenOption(data) {
-        this.pathname = common.buildPath(api.auth.REVOKE_REFRESH_TOKEN);
-        this.token = data.token;
-        ConnectionOptions.call(this);
-        this.method = 'DELETE';
-        this.body = JSON.stringify(data.body);
-    }
-    RevokeRefreshTokenOption.prototype = new ConnectionOptions();
-    RevokeRefreshTokenOption.prototype.constructor = RevokeRefreshTokenOption;
-    module.RevokeRefreshTokenOption = RevokeRefreshTokenOption;
 
     return module;
 }

--- a/api/rest/data.def.js
+++ b/api/rest/data.def.js
@@ -52,6 +52,25 @@ module.exports = function(config) {
     module.SubmitDataOption = SubmitDataOption;
 
 
+    function SubmitDataAsUserOption(data) {
+        var isBinary = common.isBinary(data.body);
+        this.pathname = common.buildPath(api.data.SEND_AS_USER, [data.accountId, data.deviceId]);
+        this.token = data.userToken;
+        ConnectionOptions.call(this);
+        this.method = 'POST';
+        if ( isBinary ) {
+            this.body = cbor.encode(data.body);
+            this.headers["Content-type"] = "application/cbor";
+        } else {
+            this.body =  JSON.stringify(data.body);
+            this.headers["Content-type"] = "application/json";
+        }
+    }
+    SubmitDataAsUserOption.prototype = new ConnectionOptions();
+    SubmitDataAsUserOption.prototype.constructor = SubmitDataAsUserOption;
+    module.SubmitDataAsUserOption = SubmitDataAsUserOption;
+
+
     function SearchDataOption(data) {
         this.pathname = common.buildPath(api.data.SEARCH, data.accountId);
         this.token = data.userToken;

--- a/api/rest/iot.auth.js
+++ b/api/rest/iot.auth.js
@@ -60,14 +60,6 @@ module.exports = function(config) {
         return module.httpClient.httpRequest(getAuthUserInfoOpt, callback);
     };
 
-    /**
-     *  @description Get refresh token through API:POST/v1/api/auth/refresh
-     *  @param data.token the access token
-     */
-    module.getRefreshToken = function(data, callback) {
-        var getRefreshTokenOpt = new module.userAdminDef.auth.GetRefreshTokenOption(data);
-        return module.httpClient.httpRequest(getRefreshTokenOpt, callback);
-    };
 
     /**
      *  @description Refresh access token through API:PUT/v1/api/auth/refresh
@@ -77,16 +69,6 @@ module.exports = function(config) {
     module.refreshAuthToken = function(data, callback) {
         var refreshAuthTokenOpt = new module.userAdminDef.auth.RefreshAuthTokenOption(data);
         return module.httpClient.httpRequest(refreshAuthTokenOpt, callback);
-    };
-
-    /**
-     *  @description Refresh access token through API:PUT/v1/api/auth/refresh
-     *  @param data.token the access token
-     *  @param data.body.refreshToken the refresh token
-     */
-    module.revokeRefreshToken = function(data, callback) {
-        var revokeRefreshTokenOpt = new module.userAdminDef.auth.RevokeRefreshTokenOption(data);
-        return module.httpClient.httpRequest(revokeRefreshTokenOpt, callback);
     };
 
     return module;

--- a/api/rest/iot.data.js
+++ b/api/rest/iot.data.js
@@ -26,13 +26,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module.exports = function(config) {
     var module = {};
-    
+
     module.httpClient = require('../../lib/httpClient');
     module.userAdminDef = require('./admin.def')(config);
-    
+
     /**
      *  @description Sends data to cloud through API:POST/v1/api/data/{deviceId}
-     *  @param data.body the data JSON object according to the API spec for this call 
+     *  @param data.body the data JSON object according to the API spec for this call
      *  @param data.userToken contains the access token
      *  @param data.deviceId id of the device which sends the data
      */
@@ -43,8 +43,21 @@ module.exports = function(config) {
 
 
     /**
+     *  @description Sends data to cloud through API:POST/v1/api/data/{deviceId}
+     *  @param data.body the data JSON object according to the API spec for this call
+     *  @param data.userToken contains the access token
+     *  @param data.deviceId id of the device which sends the data
+     *  @param data.accountId id of account that owns the device
+     */
+    module.submitDataAsUser = function(data, callback) {
+        var submitDataAsUserOpt = new module.userAdminDef.data.SubmitDataAsUserOption(data);
+        return module.httpClient.httpRequest(submitDataAsUserOpt, callback);
+    };
+
+
+    /**
      *  @description Retrieve data from cloud through API:POST/v1/api/accounts/{accountId}/data/search
-     *  @param data.body the detail of the search data JSON object according to the API spec for this call 
+     *  @param data.body the detail of the search data JSON object according to the API spec for this call
      *  @param data.userToken contains the access token
      *  @param data.accountId id of the account where the search is performed
      */
@@ -56,7 +69,7 @@ module.exports = function(config) {
 
     /**
      *  @description Retrieve data from cloud through advanced API:POST/v1/api/accounts/{accountId}/data/search/advanced
-     *  @param data.body the detail of the search data JSON object according to the API spec for this call 
+     *  @param data.body the detail of the search data JSON object according to the API spec for this call
      *  @param data.userToken contains the access token
      *  @param data.accountId id of the account where the search is performed
      */

--- a/test/api_iot.dataTests.js
+++ b/test/api_iot.dataTests.js
@@ -44,7 +44,8 @@ describe(fileToTest, function() {
     };
 
     var Option = {
-        SendDataOption: {},
+        SubmitDataOption: {},
+        SubmitDataAsUserOption: {},
         SearchDataOption: {},
         SearchDataAdvancedOption: {}
     };
@@ -76,7 +77,7 @@ describe(fileToTest, function() {
         };
 
         Option.SubmitDataOption = function(alerts) {
-            assert.deepEqual(alerts, data, "The data is not oki");
+            assert.deepEqual(alerts, data, "The data is not ok");
             return optData;
         }
         httpClientMock.httpRequest = function (opt, cb) {
@@ -92,6 +93,47 @@ describe(fileToTest, function() {
         toTest.userAdminDef.data = Option;
         toTest.submitData(data, callBack);
     });
+
+    it('Shall send submit data request as user for data submission', function(done) {
+        var optData = {
+            method: 'POST',
+            host: "myhost",
+            body: "mybody"
+        };
+
+        var data = {
+            accountid: "aid",
+            deviceid: "did",
+            body: {data: "message"}
+        };
+
+        var reData = {
+            x : 10,
+            y : 220,
+            ar : ["222", "333"]
+        };
+
+        Option.SubmitDataAsUserOption = function(alerts) {
+            assert.deepEqual(alerts, data, "The data is not ok");
+            return optData;
+        };
+
+        httpClientMock.httpRequest = function (opt, cb) {
+            assert.deepEqual(opt, optData, "the option object was missing");
+            cb(reData);
+        };
+
+        var callBack = function(response) {
+            assert.isNotNull(response, "The response was missing");
+            assert.deepEqual(response, reData, "The Data was missing");
+            done();
+        };
+
+        toTest.httpClient = httpClientMock;
+        toTest.userAdminDef.data = Option;
+        toTest.submitDataAsUser(data, callBack);
+    });
+
     it('Shall send search data request for data', function(done) {
 
         var optData = {


### PR DESCRIPTION
- Data sending: Data sending with user tokens is implemented as a seperate function
  named submitDataAsUser which uses the endpoint:
    /v1/api/accounts/{accountId}/data/{deviceId}
- Refresh tokens: No more seperate endpoint for getting and revoking them

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>